### PR TITLE
Title updated

### DIFF
--- a/web/site/app/composables/docPageData.ts
+++ b/web/site/app/composables/docPageData.ts
@@ -26,14 +26,14 @@ export function useDocPageData () {
   function createPageHead () {
     if (docPageData.value) {
       if (docPageData.value._dir === 'get-started') {
-        return `Get Started - ${docPageData.value.title} - Service BC Connect API Gateway`
+        return `Get Started - ${docPageData.value.title} | Service BC Connect Developer Site`
       } else if (docPageData.value._dir === 'connect') {
-        return `SBC Connect - ${docPageData.value.title} - Service BC Connect API Gateway`
+        return `SBC Connect - ${docPageData.value.description} | Service BC Connect Developer Site`
       } else {
-        return `${docPageData.value._dir?.toUpperCase()} - ${docPageData.value.title} - Service BC Connect API Gateway`
+        return `${docPageData.value.description} - ${docPageData.value.title} | Service BC Connect Developer Site`
       }
     } else {
-      return 'Service BC Connect API Gateway'
+      return 'Service BC Connect Developer Site'
     }
   }
 

--- a/web/site/app/pages/index.vue
+++ b/web/site/app/pages/index.vue
@@ -3,7 +3,7 @@ import { useBreadcrumbs } from '~/composables/sbcBreadcrumb'
 import { setBreadcrumbs } from '~/utils/setBreadcrumb'
 const { t } = useI18n()
 useHead({
-  title: t('page.home.title')
+  title: `${t('page.home.title')} | Service BC Connect Developer Site`
 })
 
 const breadcrumbs = useBreadcrumbs()

--- a/web/site/app/tests/unit/composables/docPageData.test.ts
+++ b/web/site/app/tests/unit/composables/docPageData.test.ts
@@ -50,7 +50,7 @@ describe('useDocPageData', () => {
     // assert current dir
     expect(composable.currentDir.value).toEqual(queryContentMockData._path)
     // assert generated page head
-    expect(composable.createPageHead()).toBe('Get Started - Test Title - Service BC Connect API Gateway')
+    expect(composable.createPageHead()).toBe('Get Started - Test Title | Service BC Connect Developer Site')
   })
 
   // TODO: figure out how to test the watcher reacting to route changes

--- a/web/site/content/en-CA/products/bn/overview.md
+++ b/web/site/content/en-CA/products/bn/overview.md
@@ -1,6 +1,6 @@
 ---
 title: 'Overview'
-description: 'Business Number Overview'
+description: 'Business Names API'
 ---
 
 # Business Names API

--- a/web/site/content/en-CA/products/br/overview.md
+++ b/web/site/content/en-CA/products/br/overview.md
@@ -1,6 +1,6 @@
 ---
 title: 'Overview'
-description: 'Business Registry Overview'
+description: 'Business Registry API'
 ---
 
 # Business Registry API

--- a/web/site/content/en-CA/products/mhr/overview.md
+++ b/web/site/content/en-CA/products/mhr/overview.md
@@ -1,6 +1,6 @@
 ---
 title: 'Overview'
-description: 'Manufactured Home Registry Overview'
+description: 'Manufactured Home Registry API'
 ---
 
 # Manufactured Home Registry API

--- a/web/site/content/en-CA/products/pay/overview.md
+++ b/web/site/content/en-CA/products/pay/overview.md
@@ -1,6 +1,6 @@
 ---
 title: 'Overview'
-description: 'Pay API Overview'
+description: 'Pay API'
 ---
 
 # Pay API

--- a/web/site/content/en-CA/products/ppr/overview.md
+++ b/web/site/content/en-CA/products/ppr/overview.md
@@ -1,6 +1,6 @@
 ---
 title: 'Overview'
-description: 'Personal Property Registry Overview'
+description: 'Personal Property Registry API'
 ---
 
 # Personal Property Registry API

--- a/web/site/content/en-CA/products/rs/overview.md
+++ b/web/site/content/en-CA/products/rs/overview.md
@@ -1,6 +1,6 @@
 ---
 title: 'Overview'
-description: 'Registry Search Overview'
+description: 'Registry Search API'
 ---
 
 # Registry Search API

--- a/web/site/package.json
+++ b/web/site/package.json
@@ -2,7 +2,7 @@
   "name": "developer-connect-site",
   "private": true,
   "type": "module",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
- Updated Title 
Homepage:
Home | Service BC Connect Developer Site

Subpages:
Get Started - Account Setup | Service BC Connect Developer Site
Get Started - About | Service BC Connect Developer Site
All Products | Service BC Connect Developer Site
Pay API - Overview | Service BC Connect Developer Site
etc.

Also, there are a few pages that are using acroynms rather than spelling out the full name in their page titles - please fix this as well.

PPR should be Personal Property Registry
RS should be Registry Search