### PR TITLE
28460 - Update API Specs for BE & FE mismatches

### DIFF
--- a/web/site/public/br/business-spec.yaml
+++ b/web/site/public/br/business-spec.yaml
@@ -5409,12 +5409,13 @@ components:
               description: 'Whether the company has liability or not: Yes/No.'
             parties:
               type: array
-              description: Can be the company directors or applicant of the filing.
+              description: Can be the company directors or applicant of the filing. This field is required for voluntary dissolution filings.
               items:
                 $ref: '#/components/schemas/party'
             courtOrder:
               $ref: '#/components/schemas/Court_order'
             custodialOffice:
+              description: 'Corporations required custodial office when applying for voluntary dissolution.'
               $ref: '#/components/schemas/Office'
             affidavitFileKey:
               type: string
@@ -6504,6 +6505,7 @@ components:
               description: Officer is a key management executive of the business
             deliveryAddress:
               $ref: '#/components/schemas/Address'
+              description: 'Required when the role type is Director or Custodian.'
             mailingAddress:
               $ref: '#/components/schemas/Address'
             title:
@@ -6602,7 +6604,7 @@ components:
           type: string
           format: email
           example: abc.def@gov.bc.ca
-          description: email address of the individual for contact information.
+          description: email address of the individual for contact information. Required for corporation voluntary dissolution filings.
       x-examples:
         Example 1:
           givenName: John


### PR DESCRIPTION
Issue #: /https://github.com/bcgov/entity/issues/28460

Description of changes:

### Updated descriptions in `business-spec.yaml`:
#### Voluntary Dissolution:
* Updated description to the parties field for voluntary dissolution: This field is required for voluntary dissolution filings.
* Updated the custodialOffice field description: Corporations required custodial office when applying for voluntary dissolution.
* Updated the email field description: “Required for corporation voluntary dissolution filings.”

#### Party's delivery address updates: 
* Added a requirement note to the deliveryAddress field: “Required when the role type is Director or Custodian.”

### Local result:
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/4aabf0c3-6a49-419b-bf31-7dc955179d01" />

