### PR TITLE
chore: upgrade packageManager to pnpm@11.9.0

### DIFF
--- a/.github/workflows/developer-connect-ui-ci.yaml
+++ b/.github/workflows/developer-connect-ui-ci.yaml
@@ -18,3 +18,4 @@ jobs:
       app_name: "developer-connect-ui"
       working_directory: "./web/site"
       codecov_flag: "devloperconnectui"
+      pnpm_version: 11.9.0

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -1,0 +1,38 @@
+name: Test pnpm v11 upgrade
+on:
+  push:
+    branches: [feat/upgrade-pnpm-v11]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/test-pnpm-v11.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+
+jobs:
+  test-pnpm-v11:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web/site
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: latest-11
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: web/site/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Report pnpm version
+        run: pnpm --version

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -32,7 +32,7 @@ jobs:
         run: pnpm install
 
       - name: Build
-        run: pnpm build
+        run: pnpm run build-check
 
       - name: Report pnpm version
         run: pnpm --version

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: latest-11
+          version: 11.9.0
 
       - uses: actions/setup-node@v6
         with:
@@ -29,7 +29,10 @@ jobs:
           cache-dependency-path: web/site/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
+
+      - name: Nuxt Prepare
+        run: pnpm exec nuxt prepare
 
       - name: Build
         run: pnpm run build-check

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -6,8 +6,10 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/test-pnpm-v11.yml'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
+      - 'web/site/.npmrc'
+      - 'web/site/package.json'
+      - 'web/site/pnpm-lock.yaml'
+      - 'web/site/pnpm-workspace.yaml'
 
 jobs:
   test-pnpm-v11:
@@ -29,13 +31,10 @@ jobs:
           cache-dependency-path: web/site/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install --ignore-scripts
-
-      - name: Nuxt Prepare
-        run: pnpm exec nuxt prepare
+        run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm run build-check
+        run: pnpm run build
 
       - name: Report pnpm version
         run: pnpm --version

--- a/web/site/package.json
+++ b/web/site/package.json
@@ -53,5 +53,5 @@
     "firebase-functions": "^4.9.0",
     "vuefire": "^3.1.24"
   },
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@11.9.0"
 }

--- a/web/site/pnpm-workspace.yaml
+++ b/web/site/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+packages: []
 allowBuilds:
   '@parcel/watcher': true
   esbuild: true

--- a/web/site/pnpm-workspace.yaml
+++ b/web/site/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  protobufjs: true
+  sharp: true
+  vue-demi: true

--- a/web/site/pnpm-workspace.yaml
+++ b/web/site/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 packages: []
+shamefullyHoist: true
+strictPeerDependencies: false
 allowBuilds:
   '@parcel/watcher': true
   esbuild: true


### PR DESCRIPTION
Sets `packageManager` to `pnpm@11.9.0` in `web/site/package.json` as part of the pnpm v11 upgrade (ticket #33875).

The Cloud Build CI trigger has already been updated to use `pnpm@11.9.0`.