### PR TITLE
[TEST] pnpm v11 upgrade - CI validation

### DIFF
--- a/.github/workflows/test-pnpm-v11-ci.yml
+++ b/.github/workflows/test-pnpm-v11-ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-pnpm-v11:
-    uses: bcgov/bcregistry-sre/.github/workflows/frontend-ci.yaml@feat/upgrade-pnpm-v11
+    uses: panish16/bcregistry-sre/.github/workflows/frontend-ci.yaml@feat/upgrade-pnpm-v11
     with:
       pnpm_version: 'latest-11'
       app_name: "developer-connect-ui"

--- a/.github/workflows/test-pnpm-v11-ci.yml
+++ b/.github/workflows/test-pnpm-v11-ci.yml
@@ -5,19 +5,8 @@ on:
     branches: ["test/pnpm-v11-upgrade"]
   workflow_dispatch:
 
-  pull_request:
-    branches: [main]
-    paths:
-      - "web/site/**"
-  workflow_dispatch:
-
-defaults:
-  run:
-    shell: bash
-    working-directory: ./web/site
-
 jobs:
-  developer-connect-ui-ci:
+  test-pnpm-v11:
     uses: bcgov/bcregistry-sre/.github/workflows/frontend-ci.yaml@feat/upgrade-pnpm-v11
     with:
       pnpm_version: 'latest-11'

--- a/.github/workflows/test-pnpm-v11-ci.yml
+++ b/.github/workflows/test-pnpm-v11-ci.yml
@@ -1,0 +1,26 @@
+name: "[TEST] pnpm v11 upgrade"
+
+on:
+  push:
+    branches: ["test/pnpm-v11-upgrade"]
+  workflow_dispatch:
+
+  pull_request:
+    branches: [main]
+    paths:
+      - "web/site/**"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./web/site
+
+jobs:
+  developer-connect-ui-ci:
+    uses: bcgov/bcregistry-sre/.github/workflows/frontend-ci.yaml@feat/upgrade-pnpm-v11
+    with:
+      pnpm_version: 'latest-11'
+      app_name: "developer-connect-ui"
+      working_directory: "./web/site"
+      codecov_flag: "devloperconnectui"


### PR DESCRIPTION
## Test PR — do not merge

This PR exists solely to trigger CI and validate that pnpm v11 is compatible.

- Runs `test-pnpm-v11.yml` (or `test-pnpm-v11-ci.yml`) which uses `pnpm@latest-11`
- Does **not** modify any existing CI workflows
- Will be closed once CI passes and the real upgrade PRs are merged

> Ticket: #33875