### PR TITLE
fix: replace discourse links with GitHub Discussions community site

### DIFF
--- a/web/site/app/pages/index.vue
+++ b/web/site/app/pages/index.vue
@@ -35,7 +35,7 @@ setBreadcrumbs([
         :title="$t('label.userForum')"
         :description="$t('text.userForum')"
         icon="i-mdi-comment-text-outline"
-        link="https://discourse.onebc.ca/"
+        link="https://github.com/bcgov/api.connect/discussions"
         external
       />
     </div>

--- a/web/site/content/en-CA/products/1.get-started/1.account-setup.md
+++ b/web/site/content/en-CA/products/1.get-started/1.account-setup.md
@@ -26,7 +26,7 @@ Start using Service BC Connect application programming interfaces (APIs) by foll
    - In the body of your email, include your BC Registries account number, name and email of your account administrator.
 9. You will be issued with a production environment API key in your Account Dashboard in the <a href="https://www.bcregistry.gov.bc.ca/" target="_blank">BC Registry application</a> which can be accessed by your Account Administrator(s).
 10. Use the API key for your queries and submission of data. Review the [Detailed API documentation](/products/get-started/apis-summary) for more information about how the APIs work.
-11. Post your technical questions and join discussions in the BC <a href="https://discourse.onebc.ca/" target="_blank">Discourse forum</a> and be sure to watch for any announcements on API outages or new features being released.
+11. Post your technical questions and join discussions in the BC <a href="https://github.com/bcgov/api.connect/discussions" target="_blank">Community site</a> and be sure to watch for any announcements on API outages or new features being released.
 12. Attend the BC Registries API User Group meetings to get updates on specifications and releases or to discuss technical questions with developers. Email BCReg.engagement@gov.bc.ca to request a meeting invitation.
 
 Questions? View our [About APIs](/products/get-started/about#frequently-asked-questions).

--- a/web/site/content/en-CA/products/br/overview.md
+++ b/web/site/content/en-CA/products/br/overview.md
@@ -96,7 +96,7 @@ All data with times are in UTC, both submitted and retrieved via the API. These 
 
 - Refer to the <a href="https://www.bcregistry.gov.bc.ca/" target="_blank">BC Registry site</a> to open an account and see all the Registry services.
 
-- Refer to the <a href="https://discourse.onebc.ca/" target="_blank">Discourse Community site</a> to answer any API and service related questions.
+- Refer to the <a href="https://github.com/bcgov/api.connect/discussions" target="_blank">Community site</a> to answer any API and service related questions.
 
 ---
 

--- a/web/site/content/en-CA/products/namex/overview.md
+++ b/web/site/content/en-CA/products/namex/overview.md
@@ -175,7 +175,7 @@ All data with times are in UTC, both submitted and retrieved via the API. These 
 
 - Refer to the <a href="https://www.bcregistry.gov.bc.ca/" target="_blank">BC Registry site</a> to open an account and see all the Registry services.
 
-- Refer to the <a href="https://discourse.onebc.ca/" target="_blank">Discourse Community site</a> to answer any API and service related questions.
+- Refer to the <a href="https://github.com/bcgov/api.connect/discussions" target="_blank">Community site</a> to answer any API and service related questions.
 
 ---
 

--- a/web/site/content/en-CA/products/rs/overview.md
+++ b/web/site/content/en-CA/products/rs/overview.md
@@ -107,7 +107,7 @@ All data with times are in UTC, both submitted and retrieved via the API. These 
 
 - Refer to the <a href="https://www.bcregistry.gov.bc.ca/" target="_blank">BC Registry site</a> to open an account and see all the Registry services.
 
-- Refer to the <a href="https://discourse.onebc.ca/" target="_blank">Discourse Community site</a> to answer any API and service related questions.
+- Refer to the <a href="https://github.com/bcgov/api.connect/discussions" target="_blank">Community site</a> to answer any API and service related questions.
 
 ---
 

--- a/web/site/content/en-CA/products/strr/overview.md
+++ b/web/site/content/en-CA/products/strr/overview.md
@@ -85,7 +85,7 @@ All data with times are in UTC, both submitted and retrieved via the API. These 
 
 - Refer to the <a href="https://www.bcregistry.gov.bc.ca/" target="_blank">BC Registry site</a> to open an account and see all the Registry services.
 
-- Refer to the <a href="https://discourse.onebc.ca/" target="_blank">Discourse Community site</a> to answer any API and service related questions.
+- Refer to the <a href="https://github.com/bcgov/api.connect/discussions" target="_blank">Community site</a> to answer any API and service related questions.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaced all `discourse.onebc.ca` links with the new [Community site](https://github.com/bcgov/api.connect/discussions) (`https://github.com/bcgov/api.connect/discussions`) across 6 pages
- Updated link text from "Discourse forum" / "Discourse Community site" to "Community site"

## Files changed

- `web/site/app/pages/index.vue` — User Forum card link
- `web/site/content/en-CA/products/1.get-started/1.account-setup.md`
- `web/site/content/en-CA/products/br/overview.md`
- `web/site/content/en-CA/products/namex/overview.md`
- `web/site/content/en-CA/products/rs/overview.md`
- `web/site/content/en-CA/products/strr/overview.md`

## Test plan

- [ ] Verify links on https://developer.connect.gov.bc.ca/en-CA open https://github.com/bcgov/api.connect/discussions
- [ ] Verify links on https://developer.api.bcregistry.gov.bc.ca/en-CA/products/get-started/account-setup
- [ ] Verify links on br, namex, rs overview pages

Resolves bcgov/entity#33978